### PR TITLE
Refactor healthcheck into infrastructure layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ make docker-run
 │   │   ├── queries/         # Запросы
 │   │   └── repositories/    # Интерфейсы репозиториев
 │   ├── application/         # Обработчики команд
+│   ├── presentation/        # HTTP контроллеры
 │   ├── infrastructure/      # Внешние сервисы
 │   └── di/                  # Dependency injection
 ├── Dockerfile
@@ -81,4 +82,4 @@ make docker-run
 
 ## Документация API
 
-Swagger UI доступен по адресу `/docs/index.html` после запуска сервиса.
+Swagger UI доступен по адресу `/swagger/index.html` (также `/swagger`) после запуска сервиса.

--- a/internal/di/wire.go
+++ b/internal/di/wire.go
@@ -8,18 +8,19 @@ import (
 	"telegram-chatbot/internal/config"
 	"telegram-chatbot/internal/domain/repositories"
 	"telegram-chatbot/internal/domain/services"
-	"telegram-chatbot/internal/infrastructure/healthcheck"
+	infraHealth "telegram-chatbot/internal/infrastructure/healthcheck"
 	infraRepo "telegram-chatbot/internal/infrastructure/repositories"
 	infraServices "telegram-chatbot/internal/infrastructure/services"
 	"telegram-chatbot/internal/infrastructure/telegram"
+	"telegram-chatbot/internal/presentation/controllers"
 
 	"github.com/google/wire"
 	"go.uber.org/zap"
 )
 
 type Container struct {
-	Bot            *telegram.Bot
-	HealthCheck    *healthcheck.Service
+	Bot         *telegram.Bot
+	HealthCheck *infraHealth.Service
 }
 
 func InitializeContainer(*config.Config) (*Container, func(), error) {
@@ -60,6 +61,11 @@ func NewClaudeAPIService(cfg *config.Config) services.ClaudeService {
 	return infraServices.NewClaudeAPIService(cfg.ClaudeAPIKey)
 }
 
-func NewHealthCheckService(cfg *config.Config, bot *telegram.Bot, logger *zap.Logger) *healthcheck.Service {
-	return healthcheck.NewHealthCheckService(bot, logger, cfg.HealthCheckPort)
+func NewHealthCheckService(cfg *config.Config, logger *zap.Logger) *infraHealth.Service {
+	srv := infraHealth.NewHealthCheckService(logger, cfg.HealthCheckPort)
+	healthCtrl := controllers.NewHealthCheckController(srv.ReadyFlag())
+	docsCtrl := controllers.NewDocumentationController()
+	healthCtrl.RegisterRoutes(srv.Router().Group("/health"))
+	docsCtrl.RegisterRoutes(srv.Router().Group("/swagger"))
+	return srv
 }

--- a/internal/di/wire_gen.go
+++ b/internal/di/wire_gen.go
@@ -12,10 +12,11 @@ import (
 	"telegram-chatbot/internal/config"
 	"telegram-chatbot/internal/domain/repositories"
 	"telegram-chatbot/internal/domain/services"
-	"telegram-chatbot/internal/infrastructure/healthcheck"
+	infraHealth "telegram-chatbot/internal/infrastructure/healthcheck"
 	repositories2 "telegram-chatbot/internal/infrastructure/repositories"
 	services2 "telegram-chatbot/internal/infrastructure/services"
 	"telegram-chatbot/internal/infrastructure/telegram"
+	"telegram-chatbot/internal/presentation/controllers"
 )
 
 // Injectors from wire.go:
@@ -32,7 +33,7 @@ func InitializeContainer(configConfig *config.Config) (*Container, func(), error
 	if err != nil {
 		return nil, nil, err
 	}
-	service := NewHealthCheckService(configConfig, bot, logger)
+	service := NewHealthCheckService(configConfig, logger)
 	container := &Container{
 		Bot:         bot,
 		HealthCheck: service,
@@ -45,7 +46,7 @@ func InitializeContainer(configConfig *config.Config) (*Container, func(), error
 
 type Container struct {
 	Bot         *telegram.Bot
-	HealthCheck *healthcheck.Service
+	HealthCheck *infraHealth.Service
 }
 
 func NewRedisSessionRepository(cfg *config.Config) repositories.SessionRepository {
@@ -77,6 +78,11 @@ func NewClaudeAPIService(cfg *config.Config) services.ClaudeService {
 	return services2.NewClaudeAPIService(cfg.ClaudeAPIKey)
 }
 
-func NewHealthCheckService(cfg *config.Config, bot *telegram.Bot, logger *zap.Logger) *healthcheck.Service {
-	return healthcheck.NewHealthCheckService(bot, logger, cfg.HealthCheckPort)
+func NewHealthCheckService(cfg *config.Config, logger *zap.Logger) *infraHealth.Service {
+	srv := infraHealth.NewHealthCheckService(logger, cfg.HealthCheckPort)
+	healthCtrl := controllers.NewHealthCheckController(srv.ReadyFlag())
+	docsCtrl := controllers.NewDocumentationController()
+	healthCtrl.RegisterRoutes(srv.Router().Group("/health"))
+	docsCtrl.RegisterRoutes(srv.Router().Group("/swagger"))
+	return srv
 }

--- a/internal/presentation/controllers/documentation_controller.go
+++ b/internal/presentation/controllers/documentation_controller.go
@@ -1,0 +1,25 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+// DocumentationController serves swagger documentation.
+type DocumentationController struct{}
+
+// NewDocumentationController creates a new DocumentationController.
+func NewDocumentationController() *DocumentationController {
+	return &DocumentationController{}
+}
+
+// RegisterRoutes registers documentation routes under the provided router group.
+func (d *DocumentationController) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.GET("", func(c *gin.Context) {
+		c.Redirect(http.StatusMovedPermanently, c.FullPath()+"/index.html")
+	})
+	rg.GET("/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+}

--- a/internal/presentation/controllers/health_controller.go
+++ b/internal/presentation/controllers/health_controller.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"sync/atomic"
+)
+
+// HealthCheckController handles health related endpoints.
+type HealthCheckController struct {
+	ready *atomic.Bool
+}
+
+// NewHealthCheckController creates a new HealthCheckController.
+func NewHealthCheckController(ready *atomic.Bool) *HealthCheckController {
+	return &HealthCheckController{ready: ready}
+}
+
+// RegisterRoutes registers health check routes under the provided router group.
+func (h *HealthCheckController) RegisterRoutes(rg *gin.RouterGroup) {
+	rg.GET("/liveness", h.liveness)
+	rg.GET("/readiness", h.readiness)
+}
+
+// liveness godoc
+// @Summary Liveness check
+// @Tags health
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Router /health/liveness [get]
+func (h *HealthCheckController) liveness(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "UP"})
+}
+
+// readiness godoc
+// @Summary Readiness check
+// @Tags health
+// @Produce json
+// @Success 200 {object} map[string]string
+// @Failure 503 {object} map[string]string
+// @Router /health/readiness [get]
+func (h *HealthCheckController) readiness(c *gin.Context) {
+	if h.ready.Load() {
+		c.JSON(http.StatusOK, gin.H{"status": "READY"})
+	} else {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "NOT_READY"})
+	}
+}


### PR DESCRIPTION
## Summary
- move healthcheck service back under infrastructure
- register controllers in DI container instead of the service
- expose router and readiness flag from health service

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684365641944832490ce4e04cc28e9dd